### PR TITLE
add disconnect method to the stream API

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,10 @@ module.exports = function(config) {
     return stream;
   };
 
+  stream.disconnect = function() {
+    conn.end();
+  };
+
   // If config was passed, connect immediately,
   // otherwise buffer until connect() is called
   if(config)


### PR DESCRIPTION
- add a method to allow the object's owner to cleanly close the
  underlying ssh connection. This may be useful i.e. while streaming
  long living commands like 'tail -f'
